### PR TITLE
Fixed pages.dateformat.default

### DIFF
--- a/config/system.yaml
+++ b/config/system.yaml
@@ -9,7 +9,7 @@ pages:
   markdown:
     extra: true
   dateformat:
-    default: 'd, Y'                          # The default date format Grav expects in the `date: ` field
+    default: 'Y-m-d'                  # The default date format Grav expects in the `date: ` field
     short: 'Y-m-d'                    # Short date format
     long: 'F jS \a\t g:ia'
 languages:


### PR DESCRIPTION
This kind of hacks shoulds not be propagated on the config level, and stay with the hack (partials/blog_item.html.twig).
Also, it breaks usage of admin plugin which use "pages.dateformat.default" with the datepicker.
